### PR TITLE
Lower node engine requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svg-path-loader",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Webpack loader to get the first path in a SVG file",
   "main": "src/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     }
   },
   "engines": {
-    "node": ">=6.1.0"
+    "node": ">=4"
   },
   "devDependencies": {
     "eslint": "^3.15.0",


### PR DESCRIPTION
Why is it there / why is it set to 6+? We're currently running it successfully (?) in 4.